### PR TITLE
Don't reuse view

### DIFF
--- a/Android.NUnitLite/AndrRunner/Elements/FormattedElement.cs
+++ b/Android.NUnitLite/AndrRunner/Elements/FormattedElement.cs
@@ -39,10 +39,7 @@ namespace Android.NUnitLite.UI {
 		
 		public override View GetView (Context context, View convertView, ViewGroup parent)
 		{
-			var view = convertView as RelativeLayout;
-			
-			if (view == null)
-				view = new RelativeLayout(context);
+			var view = new RelativeLayout(context);
 						
             var parms = new RelativeLayout.LayoutParams(ViewGroup.LayoutParams.WrapContent,
                                                         ViewGroup.LayoutParams.WrapContent);


### PR DESCRIPTION
Otherwise the previous view is also visible. This causes a problem when scrolling the test results list.
